### PR TITLE
add my opinion to versioning

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -57,5 +57,13 @@ We follow the Gitflow workflow described [here](https://www.atlassian.com/git/tu
 - merged into main and devel (or the current release branch) and main is tagged
 
 ### documentation/xxx
-- forked from main/release merged into main/release/devel.
+- remember to add an apropriate tag if merged into main/release (e.g. v1.2.3+doc1 see [Documenter.jl docs](http://mortenpi.eu/Documenter.jl/dev/man/hosting/#Documentation-Versions)
+- forked from main/release/devel merged into main/release/devel.
 - **only** changes to documentation
+
+### testing/xxx
+- changes that do not touch the code but only test
+- **only** changes that fix faulty tests or increase test coverage
+- forked from main/release/devel merged into main/release
+
+

--- a/contributing.md
+++ b/contributing.md
@@ -57,7 +57,7 @@ We follow the Gitflow workflow described [here](https://www.atlassian.com/git/tu
 - merged into main and devel (or the current release branch) and main is tagged
 
 ### documentation/xxx
-- remember to add an apropriate tag if merged into main/release (e.g. v1.2.3+doc1 see [Documenter.jl docs](http://mortenpi.eu/Documenter.jl/dev/man/hosting/#Documentation-Versions)
+- remember to add an apropriate tag if merged into main/release (e.g. v1.2.3+doc1 see [Documenter.jl docs](http://mortenpi.eu/Documenter.jl/dev/man/hosting/#Documentation-Versions))
 - forked from main/release/devel merged into main/release/devel.
 - **only** changes to documentation
 

--- a/contributing.md
+++ b/contributing.md
@@ -4,25 +4,32 @@ This file documents the release process of StructuralEquationModels.jl.
 
 ## Versioning
 
-We use semantic version for our releases. Every release has a three digit number, e.g. `2.15.7`. We partly follow recommendations described [here](https://julialang.org/blog/2019/08/release-process/) and [here](https://pkgdocs.julialang.org/v1/compatibility/).
+We use semantic versioning for our releases. Every release has a three digit number, e.g. `2.15.7`. We follow recommendations described [here](https://julialang.org/blog/2019/08/release-process/) and [here](https://pkgdocs.julialang.org/v1/compatibility/).
 
 ### Patch releases
+
 - increment the last digit of the version number
 - contain only bug fixes, low-risk performance improvements, and documentation updates
 - performance issues can also considered to be bugs
+- orthogonal features (features that are *very* unlikely to change any existing code, e.g. not using popular function names) are allowed
 
 ### Minor releases
+
 - increment the middle digit of the version number
 - new features, minor changes, refactoring of internals
 - minor changes: are unlikely to break someones code and dont break the tests
 
 ### Major releases
+
 - can break anything
-- fix/change API
+- change API
 
-### Additional notes
-- version 1.0.0 is not considered to be special.
+### Pre 1.0.0
 
+Any version 0.x.x is considered beta.
+Note that in semantic versioning pre `1.0.0` releases have different compatibility.
+`0.6.x` is not compatible to `0.5.x` but Julia deviates here from semantic versioning and considers e.g. `0.5.2` to be compatible to `0.5.3`.
+See [Pkg.jl documentation](https://pkgdocs.julialang.org/v1/compatibility/#compat-pre-1.0) for more infos.
 
 ## Workflow
 We follow the Gitflow workflow described [here](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) and [here](https://nvie.com/posts/a-successful-git-branching-model/) in large parts. We have the branches
@@ -50,5 +57,5 @@ We follow the Gitflow workflow described [here](https://www.atlassian.com/git/tu
 - merged into main and devel (or the current release branch) and main is tagged
 
 ### documentation/xxx
-- forked from main/release/devel
+- forked from main/release merged into main/release/devel.
 - **only** changes to documentation


### PR DESCRIPTION
I added four things:

1. patch releases allow "orthogonal feature". We will often encounter situation were we would like to add a new estimator, optimizer, etc. that we want to make available to collaborators. If these only add functions, do not touch existing code, and have function names that are unlikely to be used locally by users it should be fine to include them in a patch release. The intent is to quicken the pace when we use SEM.jl for a publication (where a formal version number is nice) and to not get bogged down with releasing a new version.
2. remove fix API from major releases to reduce confusion. Bugfixes are patch releases. Making a API less clumsy etc. is not a bugfix.
3. Pre 1.0.0 behaviour. It is important that we generally adhere to `Pkg`. Only where Pkg is ambiguous we can elaborate/explicate. `Pkg` figures out when it is necessary to upgrade or even downgrade `SEM.jl` to comply with other package requirements. Just because we think that `1.0.0` is no important release, `Pkg` will not think our version `0.2.0` compatible with `0.3.0`.
4. documentation/xxx Generally newly developed features should be documented, there is no special branch required, so `documentation/xxx` should not branch off from devel. It is meant to encourage adding documentation even after a feature freeze that follows  branching of a `release/xxx`. A `documentation/xxx` branch of main should happen seldomly. One example could be that users report that they find the documentation confusing.