### PR TITLE
registration triggers new release on GitHub/Zenodo

### DIFF
--- a/.github/workflows/TagBot
+++ b/.github/workflows/TagBot
@@ -1,0 +1,20 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  contents: write
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
[trigger registration](https://github.com/JuliaRegistries/Registrator.jl/) of new version with comment on a commit with [at-sign]registrator -> auto merge in general registry -> Registrator comments on successful registration -> comment triggers this github action which auto generates a release