### PR TITLE
reduce export footprint of StenoGraph

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,6 +29,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 julia = "1.7"
+StenoGraphs = "≥ 0.2.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/StructuralEquationModels.jl
+++ b/src/StructuralEquationModels.jl
@@ -7,10 +7,7 @@ using LinearAlgebra, Optim,
     DataFrames, Zygote, ChainRulesCore
 
 import DataFrames: DataFrame
-export *, ==, @StenoGraph, AbstractEdge, AbstractNode, DirectedEdge, Edge, EdgeModifier, 
-    MetaEdge, MetaNode, ModifiedEdge, ModifiedNode, Modifier, ModifyingNode, Node, 
-    NodeModifier, NodeOrEdgeModifier, SimpleNode, StenoGraphs, UndirectedEdge, convert, 
-    promote_rule, show, unarrow, unmeta, ←, →, ↔, ⇐, ⇒, ⇔, meld
+export StenoGraphs, @StenoGraph, meld
 
 # type hierarchy
 include("types.jl")


### PR DESCRIPTION
closes #92

works in independent projects:

```
import Pkg
Pkg.add(url="https://github.com/StructuralEquationModels/StructuralEquationModels.jl/", rev = "hotfix/stenograph-export")
using StructuralEquationModels
#using StenoGraphs

observed_vars = [:x1, :x2, :x3, :y1, :y2, :y3, :y4, :y5, :y6, :y7, :y8]
latent_vars = [:ind60, :dem60, :dem65]

graph = @StenoGraph begin

    # loadings
    ind60 → fixed(1)*x1 + x2 + x3
    dem60 → fixed(1)*y1 + y2 + y3 + y4
    dem65 → fixed(1)*y5 + y6 + y7 + y8

    # latent regressions
    dem60 ← ind60
    dem65 ← dem60
    dem65 ← ind60

    # variances
    _(observed_vars) ↔ _(observed_vars)
    _(latent_vars) ↔ _(latent_vars)

    # covariances
    y1 ↔ y5
    y2 ↔ y4 + y6
    y3 ↔ y7
    y8 ↔ y4 + y6

    # means
    Symbol("1") → _(observed_vars)
end
```

but lets see what the CI says :)