### PR TITLE
CI: add julia-format action

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -7,7 +7,4 @@ jobs:
   code-style:
     runs-on: ubuntu-latest
     steps:
-    - uses: julia-actions/julia-format@v2
-      with:
-        julia-version: '1'
-        suggestion-label: 'format suggestion'
+    - uses: julia-actions/julia-format@master

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -7,4 +7,7 @@ jobs:
   code-style:
     runs-on: ubuntu-latest
     steps:
-    - uses: julia-actions/julia-format@master
+      - uses: julia-actions/julia-format@v3
+        with:
+          version: '1'
+          suggestion-label: 'format-suggest'

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,13 @@
+name: Format suggestions
+on:
+  pull_request:
+    # this argument is not required if you don't use the `suggestion-label` input
+    types: [ opened, reopened, synchronize, labeled, unlabeled ]
+jobs:
+  code-style:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: julia-actions/julia-format@v2
+      with:
+        julia-version: '1'
+        suggestion-label: 'format suggestion'

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -7,7 +7,7 @@ jobs:
   code-style:
     runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/julia-format@v3
+      - uses: julia-actions/julia-format@v2
         with:
           version: '1'
           suggestion-label: 'format-suggest'


### PR DESCRIPTION
This adds the automatic format check via [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl) and GitHub code suggestions using [julia-format](https://github.com/julia-actions/julia-format) action.
This is an example of how it would look: https://github.com/alyst/StructuralEquationModels.jl/pull/2

Note that it would only suggest code formatting to the files modified by the PR, so to format the whole current codebase, a separate PR is required (it is as simple as running `using JuliaFormatter; format(".")` -- *JuliaFormatter* don't have to be a SEM.jl dependency, you can install it in the temporary Julia project; just the working folder should point to *SEM.jl*).
The formatting rules are specified in .JuliaFormatter.toml. Right now it is using the default formatting style.
Check the JuliaFormatter.jl docs for how to tune it to match to your preference.

I thought that it would be nice to fix the formatting before #181. One reason -- that PR contains many no-op whitespace changes (removal of trailing whitespace etc), which compilcate the review.

Fixes #169