### PR TITLE
Update loss checks

### DIFF
--- a/src/loss/ML/ML.jl
+++ b/src/loss/ML/ML.jl
@@ -39,19 +39,18 @@ end
 ############################################################################################
 
 function SemML(; observed::SemObserved, approximate_hessian::Bool = false, kwargs...)
-
     if observed isa SemObservedMissing
-        throw(ArgumentError(
-            "Normal maximum likelihood estimation can't be used with `SemObservedMissing`.
-            Use full information maximum likelihood (FIML) estimation or remove missing 
-            values in your data.
-            A FIML model can be constructed with 
-            Sem(
-                ...,
-                observed = SemObservedMissing,
-                loss = SemFIML,
-                meanstructure = true
-            )"))
+        @warn """
+        ML estimation with `SemObservedMissing` will use an approximate covariance and mean estimated with EM algorithm.
+        For more accurate results, consider using full information maximum likelihood (FIML) estimation or remove missing values in your data.
+        A FIML model can be constructed with
+        Sem(
+            ...,
+            observed = SemObservedMissing,
+            loss = SemFIML,
+            meanstructure = true
+        )
+        """
     end
 
     obsmean = obs_mean(observed)

--- a/src/loss/WLS/WLS.jl
+++ b/src/loss/WLS/WLS.jl
@@ -58,24 +58,24 @@ function SemWLS(;
     meanstructure = false,
     kwargs...,
 )
-
     if observed isa SemObservedMissing
-        throw(ArgumentError(
-            "WLS estimation can't be used with `SemObservedMissing`.
-            Use full information maximum likelihood (FIML) estimation or remove missing 
-            values in your data.
-            A FIML model can be constructed with 
-            Sem(
-                ...,
-                observed = SemObservedMissing,
-                loss = SemFIML,
-                meanstructure = true
-            )"))
+        @warn """
+        WLS estimation with `SemObservedMissing` will use an approximate covariance and mean estimated with EM algorithm.
+        For more accurate results, consider using full information maximum likelihood (FIML) estimation or remove missing values in your data.
+        A FIML model can be constructed with
+        Sem(
+            ...,
+            observed = SemObservedMissing,
+            loss = SemFIML,
+            meanstructure = true
+        )
+        """
     end
 
-    if !(implied isa RAMSymbolic) 
-        throw(ArgumentError(
-            "WLS estimation is only available with the implied type RAMSymbolic at the moment."))
+    if !(implied isa RAMSymbolic)
+        "WLS estimation is only available with the implied type RAMSymbolic at the moment." |>
+        ArgumentError |>
+        throw
     end
 
     nobs_vars = nobserved_vars(observed)

--- a/src/observed/data.jl
+++ b/src/observed/data.jl
@@ -38,22 +38,24 @@ function SemObservedData(;
     observed_var_prefix::Union{Symbol, AbstractString} = :obs,
     kwargs...,
 )
-
     data, obs_vars, _ =
         prepare_data(data, observed_vars, specification; observed_var_prefix)
     obs_mean, obs_cov = mean_and_cov(data, 1)
 
-    if any(ismissing.(data))
-        throw(ArgumentError(
-            "Your dataset contains missing values.
-            Remove missing values or use full information maximum likelihood (FIML) estimation.
-            A FIML model can be constructed with 
-            Sem(
-                ...,
-                observed = SemObservedMissing,
-                loss = SemFIML,
-                meanstructure = true
-            )"))
+    if any(ismissing, data)
+        """
+        Your dataset contains missing values.
+        Remove missing values or use full information maximum likelihood (FIML) estimation.
+        A FIML model can be constructed with
+        Sem(
+            ...,
+            observed = SemObservedMissing,
+            loss = SemFIML,
+            meanstructure = true
+        )
+        """ |>
+        ArgumentError |>
+        throw
     end
 
     return SemObservedData(data, obs_vars, obs_cov, vec(obs_mean), size(data, 1))


### PR DESCRIPTION
The PR slightly tweaks the recently introduced checks that the SEM loss function uses the compatible `SemObserved` object:
  * Instead of throwing an error, it allows using `SemObservedMissing` for `SemML` and `SemWLS`, but shows a warning that approximate cov/mean will be used.
    In my use cases it is actually unfeasible to use FIML, because of the large number of observed vars and missing patterns, but EM-based approximation works quite well with SemML
  * The missingness check in `SemObservedData` is tweaked to avoid generating temporary array, which could be quite large
  * The messages introduced by these checks are multiline and contain indentation + they respect the indentation of the surrounding code.
     The correct way to define such messages is to use indented `"""` strings -- the indentation of `"""` is subtracted from the string indentation, so they are not overindented when printed.
  * I have also switched to the pipe syntax for these messages, because it results in fewer indentations + potentially more readable overall